### PR TITLE
Don't break system utilities on use of bins property

### DIFF
--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -500,19 +500,30 @@ use strict;
 use warnings;
 use File::ShareDir ':ALL';
 use Path::Class;
+use File::Which;
+use {{ $mod }};
 
-my $abs = file(dist_dir('{{ $dist->name }}'),'bin','{{ $bin }}')->cleanup->absolute;
+my $abs;
+if({{ $mod }}->install_type ne 'system') {
+	$abs = file(dist_dir('{{ $dist->name }}'),'bin','{{ $bin }}')->cleanup->absolute;
+} else {
+	my @opts = which '{{ $bin }}';
+	$abs = $opts[1];
+}
 
 exec($abs, @ARGV) or print STDERR "couldn't exec {{ $bin }}: $!";
 
 __EOT__
 
 	for (@{$self->split_bins}) {
+		my $module = $self->zilla->name;
+		$module =~ s/-/::/g;
 		my $content = $self->fill_in_string(
 			$template,
 			{
 				dist => \($self->zilla),
 				bin => $_,
+				mod => $module,
 			},
 		);
 


### PR DESCRIPTION
When alien_version_check is set, we may end up depending on the
system-installed version of the built package. In that case, the
absolute path in the dist_dir won't be available, and the binaries fail
to work.

Check for that using the ConfigData package, and use the binary in
/usr/bin directlry, assuming it's installed there.